### PR TITLE
Remove Body From Challenge Requests

### DIFF
--- a/lib/ntlm/http.rb
+++ b/lib/ntlm/http.rb
@@ -23,6 +23,8 @@ module Net
       end
 
       unless started?
+        @original_body = req.body
+        req.body = nil
         start do
           req.delete('connection')
           return request(req, body, &block)
@@ -39,6 +41,7 @@ module Net
         user, domain, password = req.ntlm_auth_params
         req['authorization'] = 'NTLM ' + NTLM.authenticate(challenge, user, domain, password).to_base64
         req.body_stream.rewind if req.body_stream
+        req.body = @original_body
         request_without_ntlm_auth(req, body, &block)  # We must re-use the connection.
       else
         yield res if block_given?

--- a/lib/ntlm/http.rb
+++ b/lib/ntlm/http.rb
@@ -32,14 +32,14 @@ module Net
       end
 
       # Negotiation
-      req['authorization'] = 'NTLM ' + NTLM.negotiate.to_base64
+      req['authorization'] = 'NTLM ' + ::NTLM.negotiate.to_base64
       res = request_without_ntlm_auth(req, body)
       challenge = res['www-authenticate'][/NTLM (.*)/, 1].unpack('m').first rescue nil
 
       if challenge && res.code == '401'
         # Authentication
         user, domain, password = req.ntlm_auth_params
-        req['authorization'] = 'NTLM ' + NTLM.authenticate(challenge, user, domain, password).to_base64
+        req['authorization'] = 'NTLM ' + ::NTLM.authenticate(challenge, user, domain, password).to_base64
         req.body_stream.rewind if req.body_stream
         req.body = @original_body
         request_without_ntlm_auth(req, body, &block)  # We must re-use the connection.

--- a/lib/ntlm/imap.rb
+++ b/lib/ntlm/imap.rb
@@ -24,9 +24,9 @@ module Net
       def process(data)
         case (@state += 1)
         when 1
-          NTLM.negotiate.to_s
+          ::NTLM.negotiate.to_s
         when 2
-          NTLM.authenticate(data, @user, @domain, @password).to_s
+          ::NTLM.authenticate(data, @user, @domain, @password).to_s
         end
       end
     end # NTLMAuthenticator

--- a/lib/ntlm/version.rb
+++ b/lib/ntlm/version.rb
@@ -1,5 +1,5 @@
 # vim: set et sw=2 sts=2:
 
 module NTLM
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/lib/ntlm/version.rb
+++ b/lib/ntlm/version.rb
@@ -1,5 +1,5 @@
 # vim: set et sw=2 sts=2:
 
 module NTLM
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/ruby-ntlm.gemspec
+++ b/ruby-ntlm.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
Problem: In most cases, it is fine to send the body of a challenge request, and again in the authenticated request. However, in some load-balanced Sharepoint environments, sending a large body in both requests can result in 401 Unauthorized requests from the server. This appears to be a result of reaching different backend servers for the challenge and the authenticated requests, as it does not occur when connecting to a single backend server in the same Sharepoint farm.

Solution: Remove the body from the challenge request, if this request already includes a body, and reattach the body to the authentication request. This appears to have removed all of the intermittent 401 responses.