### PR TITLE
Properly resolve NTLM module when used inside NET.

### DIFF
--- a/lib/ntlm/http.rb
+++ b/lib/ntlm/http.rb
@@ -30,14 +30,14 @@ module Net
       end
 
       # Negotiation
-      req['authorization'] = 'NTLM ' + NTLM.negotiate.to_base64
+      req['authorization'] = 'NTLM ' + ::NTLM.negotiate.to_base64
       res = request_without_ntlm_auth(req, body)
       challenge = res['www-authenticate'][/NTLM (.*)/, 1].unpack('m').first rescue nil
 
       if challenge && res.code == '401'
         # Authentication
         user, domain, password = req.ntlm_auth_params
-        req['authorization'] = 'NTLM ' + NTLM.authenticate(challenge, user, domain, password).to_base64
+        req['authorization'] = 'NTLM ' + ::NTLM.authenticate(challenge, user, domain, password).to_base64
         req.body_stream.rewind if req.body_stream
         request_without_ntlm_auth(req, body, &block)  # We must re-use the connection.
       else

--- a/lib/ntlm/imap.rb
+++ b/lib/ntlm/imap.rb
@@ -24,9 +24,9 @@ module Net
       def process(data)
         case (@state += 1)
         when 1
-          NTLM.negotiate.to_s
+          ::NTLM.negotiate.to_s
         when 2
-          NTLM.authenticate(data, @user, @domain, @password).to_s
+          ::NTLM.authenticate(data, @user, @domain, @password).to_s
         end
       end
     end # NTLMAuthenticator


### PR DESCRIPTION
NTLM  constant referred from e.g. Net module would be resolved as ::Net::NTLM due to Ruby constant resolution rule. 

Such a use case happened  adding 'http-ntlm' gem (referred by 'mechanize')  to the project. 
`http-ntlm` defines `Net::NTLM` module: https://github.com/pyu10055/ntlm-http/blob/master/lib/net/ntlm.rb
which lead to incorrect resolution of NTLM constant.

Being referred inside another module, it is safe to specify full path to the constant
like `::NTLM.do_something`.